### PR TITLE
Add option to generate all Getter and Setter methods at once

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,25 +48,67 @@ export function activate(context: vscode.ExtensionContext) {
         if (readyCheck()) DefinitionProvider.instance.refreshExports();
     }));
     context.subscriptions.push(vscode.commands.registerCommand('genGetSet.getter', function () {
-        const classesList = generateClassesList(EType.GETTER);
-        vscode.window.showQuickPick(
-            quickPickItemListFrom(classesList, EType.GETTER)).then((pickedItem) => {
-                generateCode(classesList, EType.GETTER, pickedItem);
-            });
+        let classesList = generateClassesList(EType.GETTER);
+
+        // Add ALL option
+        let addAllClass: any = {name: 'any', vars: [{name: 'Add all', typeName:'Getters'}]};
+        classesList.unshift(addAllClass);
+
+        const extendedClassesList = classesList;
+        const quickPickItemList: vscode.QuickPickItem[] = quickPickItemListFrom(extendedClassesList, EType.GETTER);
+        vscode.window.showQuickPick(quickPickItemList).then((pickedItem) => {
+            let auxPickedItemList: vscode.QuickPickItem[] = [];
+            // Check if ALL option was selected
+            if(pickedItem.label == 'Add all') 
+                auxPickedItemList = quickPickItemList.splice(1,quickPickItemList.length-1);
+            else 
+                auxPickedItemList.push(pickedItem);    
+            // Generate multiple getters and setter after remove added auxiliary ALL Option
+            generateCode(extendedClassesList.splice(1,extendedClassesList.length-1), EType.GETTER, 
+                auxPickedItemList);
+        });
     }));
     context.subscriptions.push(vscode.commands.registerCommand('genGetSet.setter', function () {
-        const classesList = generateClassesList(EType.SETTER);
-        vscode.window.showQuickPick(
-            quickPickItemListFrom(classesList, EType.SETTER)).then((pickedItem) => {
-                generateCode(classesList, EType.SETTER, pickedItem);
-            });
+        let classesList = generateClassesList(EType.SETTER);
+
+        // Add ALL option
+        let addAllClass: any = {name: 'any', vars: [{name: 'Add all', typeName:'Setters'}]};
+        classesList.unshift(addAllClass);
+
+        const extendedClassesList = classesList;
+        const quickPickItemList: vscode.QuickPickItem[] = quickPickItemListFrom(extendedClassesList, EType.SETTER);
+        vscode.window.showQuickPick(quickPickItemList).then((pickedItem) => {
+            let auxPickedItemList: vscode.QuickPickItem[] = [];
+            // Check if ALL option was selected
+            if(pickedItem.label == 'Add all') 
+                auxPickedItemList = quickPickItemList.splice(1,quickPickItemList.length-1);
+            else 
+                auxPickedItemList.push(pickedItem);    
+            // Generate multiple getters and setter after remove added auxiliary ALL Option
+            generateCode(extendedClassesList.splice(1,extendedClassesList.length-1), EType.SETTER, 
+                auxPickedItemList);
+        });
     }));
     context.subscriptions.push(vscode.commands.registerCommand('genGetSet.getterAndSetter', function () {
-        const classesList = generateClassesList(EType.BOTH);
-        vscode.window.showQuickPick(
-            quickPickItemListFrom(classesList, EType.BOTH)).then((pickedItem) => {
-                generateCode(classesList, EType.BOTH, pickedItem);
-            });
+        let classesList = generateClassesList(EType.BOTH);
+
+        // Add ALL option
+        let addAllClass: any = {name: 'any', vars: [{name: 'Add all', typeName:'Getters and Setters'}]};
+        classesList.unshift(addAllClass);
+
+        const extendedClassesList = classesList;
+        const quickPickItemList: vscode.QuickPickItem[] = quickPickItemListFrom(extendedClassesList, EType.BOTH);
+        vscode.window.showQuickPick(quickPickItemList).then((pickedItem) => {
+            let auxPickedItemList: vscode.QuickPickItem[] = [];
+            // Check if ALL option was selected
+            if(pickedItem.label == 'Add all') 
+                auxPickedItemList = quickPickItemList.splice(1,quickPickItemList.length-1);
+            else 
+                auxPickedItemList.push(pickedItem);    
+            // Generate multiple getters and setter after remove added auxiliary ALL Option
+            generateCode(extendedClassesList.splice(1,extendedClassesList.length-1), EType.BOTH, 
+                auxPickedItemList);
+        });
     }));
     context.subscriptions.push(vscode.commands.registerCommand('genGetSet.constructor', function () {
         const classesList = generateClassesList(EType.BOTH);

--- a/src/getset.ts
+++ b/src/getset.ts
@@ -27,23 +27,24 @@ const matchers = {
 }
 
 // generate code lines into the current active window based on EType
-export function generateCode(classes: IClass[], type: EType, pickedItem?: vscode.QuickPickItem) {
+export function generateCode(classes: IClass[], type: EType, pickedItems?: vscode.QuickPickItem[]) {
     const currentPos = new vscode.Position(vscode.window.activeTextEditor.selection.active.line, 0);
-    if (type !== EType.CONSTRUCTOR && pickedItem) {
-        const _class = getClass(classes, pickedItem.description);
+    if (type !== EType.CONSTRUCTOR && (pickedItems && (pickedItems.length > 0))) {
+        const _class = getClass(classes, pickedItems[0].description);
         if (_class) {
-            for (let i = 0; i < _class.vars.length; i++) {
-                var item = _class.vars[i];
-                if (item && pickedItem.label === item.name) {
-                    vscode.window.activeTextEditor.edit((builder) => {
-                        // add template code blocks before the cursor position's line number
-                        if (type == EType.GETTER || type == EType.BOTH)
-                            builder.insert(currentPos, createGetter(item));
-                        if (type == EType.SETTER || type == EType.BOTH)
-                            builder.insert(currentPos, createSetter(item));
+            vscode.window.activeTextEditor.edit((builder) => {
+                _class.vars.forEach(item =>{
+                    pickedItems.forEach((pickedItem)=>{
+                        if (pickedItem.label === item.name) {
+                            // add template code blocks before the cursor position's line number
+                            if (type == EType.GETTER || type == EType.BOTH)
+                                builder.insert(currentPos, createGetter(item));
+                            if (type == EType.SETTER || type == EType.BOTH)
+                                builder.insert(currentPos, createSetter(item));
+                        }
                     });
-                }
-            }
+                });
+            });
         }
     } else if (type === EType.CONSTRUCTOR) {
         vscode.window.activeTextEditor.edit((builder) => {
@@ -229,4 +230,16 @@ function getClass(items: IClass[], name: string): IClass {
         }
     }
     return null;
+}
+function getClasses(items: IClass[], pickedItems: vscode.QuickPickItem[]): IClass[] {
+    let auxItems: IClass[] = [];
+
+    for(let j = 0; j < pickedItems.length; j++){
+        for (let i = 0; i < items.length; i++) {
+            if (items[i].name === pickedItems[j].description) {
+                auxItems.push(items[i]);
+            }
+        }
+    }
+    return auxItems;
 }


### PR DESCRIPTION
An auxiliary option has been added to showQuickPick named Add all that will
generate all Getters and Setters method in a class.

Also, for loops within generateCode has been refactored to forEach methods
of TypeScript.